### PR TITLE
Fix duplicate exception handling in UrlBar.load_page

### DIFF
--- a/Bin/src/ui/widgets.py
+++ b/Bin/src/ui/widgets.py
@@ -99,22 +99,15 @@ class UrlBar(ttk.Frame):
             self.logger.error(f"Failed to load page: {str(e)}")
         finally:
             # Ensure button is reset only if it still exists
-            if self.go_btn.winfo_exists() and self.go_btn.winfo_ismapped():
-                self.reset_go_button()
-            else:
-                self.logger.warning("Go button does not exist, skipping reset.")
-
-        except Exception as e:
-            self.logger.error(f"Failed to load page: {str(e)}")
-        finally:
-            # Ensure button is reset only if it still exists
             try:
                 if self.go_btn.winfo_exists() and self.go_btn.winfo_ismapped():
                     self.reset_go_button()
                 else:
                     self.logger.warning("Go button does not exist, skipping reset.")
             except tk.TclError:
-                self.logger.warning("Failed to reset Go button; widget might have been destroyed.")
+                self.logger.warning(
+                    "Failed to reset Go button; widget might have been destroyed."
+                )
 
 
     def reset_go_button(self):


### PR DESCRIPTION
## Summary
- clean up duplicate `except`/`finally` blocks in `UrlBar.load_page`
- ensure `Go` button resets in one unified `finally` section

## Testing
- `PYTHONPATH=./Bin pytest -q` *(fails: ModuleNotFoundError: No module named 'agent_executive')*

------
https://chatgpt.com/codex/tasks/task_e_684065db6990832780f4e52e92bebbbc